### PR TITLE
Bugfix v0.4

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -107,5 +107,5 @@ jobs:
       - run: |
           # --uenv-mount=.... without --uenv-mount-file must return an error
           su testuser -c sh <<\EOF
-          ci/tests/uenv-mount-point-alone.sh
+          srun --uenv-mount=/user-environment -v true |& grep 'srun: error: --uenv-mount'
           EOF

--- a/ci/tests/plain.sbatch
+++ b/ci/tests/plain.sbatch
@@ -5,26 +5,8 @@
 
 # if --uenv-file is not specified, the plugin should not mount anything
 
-
 # user-environment is mounted unexpectedly
 if [[ $(findmnt | grep -vc /user-environment) -ne $(findmnt | wc -l)  ]];
 then
     exit 1
 fi
-
-
-# # this always fails, I don't understand why
-# srun sh <<\EOF
-#     if [[ $(findmnt | grep -bc /user-environment) -ne $(findmnt | wc -l)  ]];
-#     then
-#         exit 1
-#     fi
-# EOF
-
-# # this is expected to run silently
-# srun --uenv-mount=/foo sh <<\EOF
-#     if [[ $(findmnt | grep -bc /user-environment) -ne $(findmnt | wc -l)  ]];
-#     then
-#         exit 1
-#     fi
-# EOF

--- a/ci/tests/uenv-mount-point-alone.sh
+++ b/ci/tests/uenv-mount-point-alone.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# non-existent mount point
-(srun -n 1 --uenv-mount=/user-environment true) |& grep 'uenv-mount is only allowed to be used together with --uenv-file' || exit 1

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -70,7 +70,7 @@ static spank_option mount_point_arg{
     1, // requires an argument
     0, // plugin specific value to pass to the callback (unnused)
     [](int val, const char *optarg, int remote) -> int {
-      slurm_info("uenv-mount: val:%d optarg:%s remote:%d", val, optarg,
+      slurm_verbose("uenv-mount: val:%d optarg:%s remote:%d", val, optarg,
                  remote);
       // todo: parse string to validate that the path exists
       // todo: parse string to validate that it is a valid and allowed path
@@ -86,7 +86,7 @@ static spank_option file_arg{
     1, // requires an argument
     0, // plugin specific value to pass to the callback (unnused)
     [](int val, const char *optarg, int remote) -> int {
-      slurm_info("uenv-mount: val:%d optarg:%s remote:%d", val, optarg,
+      slurm_verbose("uenv-mount: val:%d optarg:%s remote:%d", val, optarg,
                  remote);
       // check that file exists happens in do_mount
       args.file = std::string{optarg};
@@ -100,7 +100,7 @@ static spank_option prolog_arg{
     0, // takes an argument
     0, // plugin specific value to pass to the callback (unnused)
     [](int val, const char *optarg, int remote) -> int {
-      slurm_info("uenv-mount: val:%d optarg:%s remote:%d", val, optarg,
+      slurm_verbose("uenv-mount: val:%d optarg:%s remote:%d", val, optarg,
                  remote);
       args.run_prologue = false;
       return ESPANK_SUCCESS;

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -6,8 +6,8 @@
 #include "mount.hpp"
 
 extern "C" {
-#include <slurm/spank.h>
 #include <slurm/slurm_errno.h>
+#include <slurm/spank.h>
 }
 
 //
@@ -52,9 +52,9 @@ int slurm_spank_init_post_opt(spank_t sp, int ac, char **av) {
 // Implementation
 //
 namespace impl {
-
+#define DEFAULT_MOUNT_POINT "/user-environment"
 struct arg_pack {
-  std::string mount_point = "/user-environment";
+  std::string mount_point = DEFAULT_MOUNT_POINT;
   bool mount_flag_present = false;
   std::optional<std::string> file;
   bool run_prologue = false;
@@ -65,13 +65,13 @@ static arg_pack args{};
 static spank_option mount_point_arg{
     (char *)"uenv-mount",
     (char *)"<path>",
-    (char *)"path whence the environment is mounted: default "
-            "/user-environment",
+    (char *)"path whence the environment is mounted: "
+            "default " DEFAULT_MOUNT_POINT,
     1, // requires an argument
     0, // plugin specific value to pass to the callback (unnused)
     [](int val, const char *optarg, int remote) -> int {
       slurm_verbose("uenv-mount: val:%d optarg:%s remote:%d", val, optarg,
-                 remote);
+                    remote);
       // todo: parse string to validate that the path exists
       // todo: parse string to validate that it is a valid and allowed path
       args.mount_point = optarg;
@@ -87,7 +87,7 @@ static spank_option file_arg{
     0, // plugin specific value to pass to the callback (unnused)
     [](int val, const char *optarg, int remote) -> int {
       slurm_verbose("uenv-mount: val:%d optarg:%s remote:%d", val, optarg,
-                 remote);
+                    remote);
       // check that file exists happens in do_mount
       args.file = std::string{optarg};
       return ESPANK_SUCCESS;
@@ -101,7 +101,7 @@ static spank_option prolog_arg{
     0, // plugin specific value to pass to the callback (unnused)
     [](int val, const char *optarg, int remote) -> int {
       slurm_verbose("uenv-mount: val:%d optarg:%s remote:%d", val, optarg,
-                 remote);
+                    remote);
       args.run_prologue = false;
       return ESPANK_SUCCESS;
     }};
@@ -143,7 +143,7 @@ int slurm_spank_init(spank_t sp, int ac, char **av) {
 }
 
 int slurm_spank_init_post_opt(spank_t sp, int, char **av) {
-  if(!args.file && args.mount_flag_present) {
+  if (!args.file && args.mount_flag_present) {
     slurm_error(
         "--uenv-mount is only allowed to be used together with --uenv-file.");
     return ESPANK_ERROR;

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -26,7 +26,7 @@ int slurm_spank_init_post_opt(spank_t sp, int ac, char **av);
 
 extern "C" {
 
-extern const char plugin_name[] = "sqfs-spank-mount";
+extern const char plugin_name[] = "uenv-mount";
 extern const char plugin_type[] = "spank";
 #ifdef SLURM_VERSION_NUMBER
 extern const unsigned int plugin_version = SLURM_VERSION_NUMBER;

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -144,9 +144,9 @@ int slurm_spank_local_user_init(spank_t sp, int ac, char **av) {
   if (!args.file) {
     // ensure that --uenv-mount is not present, getopt is called here
     // because it is not allowed to be called in `spank_init`.
-    char** tmp{nullptr};
-    spank_err_t ret = spank_option_getopt(sp, &mount_point_arg, tmp);
-    if (ret != ESPANK_ERROR) {
+    char* buf;
+    spank_err_t ret = spank_option_getopt(sp, &mount_point_arg, &buf);
+    if (ret == ESPANK_SUCCESS) {
       slurm_error("--uenv-mount is only allowed to be used together with --uenv-file.");
       return ESPANK_ERROR;
     }

--- a/slurm-uenv-mount.spec
+++ b/slurm-uenv-mount.spec
@@ -25,7 +25,8 @@ make install prefix=%{_prefix} DESTDIR=%{buildroot}
 %post
 REQ="required /usr/lib64/libslurm-uenv-mount.so"
 CNF=/etc/plugstack.conf.d/99-slurm-uenv-mount.conf
-echo "$REQ" >> "$CNF"
+mkdir -p /etc/plugstack.conf.d
+echo "$REQ" > "$CNF"
 
 %files
 %license LICENSE


### PR DESCRIPTION
- fix mistake in check if `--uenv-mount` was given without `--uenv-file`
- update tests accordingly
- rpm postinall: make sure `/etc/plugstack.conf.d` exists (`mkdir -p`)