### PR TITLE
WIP: update ci and check for non-zero exit code

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -74,20 +74,8 @@ jobs:
           /entrypoint.sh
           sinfo
           ci/create-dummy-sqfs.sh
-          expect_error()
-          {
-              (
-                  set +e
-                  if  ! (eval "$1") ; then
-                      return 0
-                  fi
-                  return 1
-              )
-          }
-          export -f expect_error
       - run: |
           # verify that nothing is mounted when no --uenv-file flag is given
-          type expect_error
           su testuser -c sh <<\EOF
           sbatch --wait ci/tests/plain.sbatch || exit 1
           EOF
@@ -109,17 +97,16 @@ jobs:
       - run: |
           # verify that attempting to mount an non-existent image fails
           su testuser -c sh <<\EOF
-          expect_error 'srun --uenv-file=/does/not/exist true'
+          ci/tests/invalid-image.sh
           EOF
       - run: |
           # verify attempting to mount under an non-existent path fails
           su testuser -c -m sh <<\EOF
-          expect_error 'srun -n 1 --uenv-file=/home/testuser/fs.sqfs --uenv-mount=/path/does/not/exist true'
+          ci/tests/invalid-file.sh
           EOF
       - run: |
           # --uenv-mount=.... without --uenv-mount-file must return an error
           su testuser -c -m sh <<\EOF
           # this is expected to vail
-          expect_error 'srun --uenv-mount=/user-environment -v true'
-          expect_error 'srun --uenv-file=/home/testuser/fs.sqfs --uenv-mount=/user-environment -v true'
+          ci/tests/invalid-flags.sh
           EOF

--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -74,6 +74,17 @@ jobs:
           /entrypoint.sh
           sinfo
           ci/create-dummy-sqfs.sh
+          expect_error()
+          {
+              (
+                  set +e
+                  if  ! (eval "$1") ; then
+                      return 0
+                  fi
+                  return 1
+              )
+          }
+          export -f expect_error
       - run: |
           # verify that nothing is mounted when no --uenv-file flag is given
           su testuser -c sh <<\EOF
@@ -97,15 +108,17 @@ jobs:
       - run: |
           # verify that attempting to mount an non-existent image fails
           su testuser -c sh <<\EOF
-          ci/tests/invalid-image.sh
+          expect_error 'srun --uenv-file=/does/not/exist true'
           EOF
       - run: |
           # verify attempting to mount under an non-existent path fails
-          su testuser -c sh <<\EOF
-          ci/tests/invalid-mount-point.sh
+          su testuser -c -m sh <<\EOF
+          expect_error 'srun -n 1 --uenv-file=/home/testuser/fs.sqfs --uenv-mount=/path/does/not/exist true'
           EOF
       - run: |
           # --uenv-mount=.... without --uenv-mount-file must return an error
-          su testuser -c sh <<\EOF
-          srun --uenv-mount=/user-environment -v true |& grep 'srun: error: --uenv-mount'
+          su testuser -c -m sh <<\EOF
+          # this is expected to vail
+          expect_error 'srun --uenv-mount=/user-environment -v true'
+          expect_error 'srun --uenv-file=/home/testuser/fs.sqfs --uenv-mount=/user-environment -v true'
           EOF

--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -87,6 +87,7 @@ jobs:
           export -f expect_error
       - run: |
           # verify that nothing is mounted when no --uenv-file flag is given
+          type expect_error
           su testuser -c sh <<\EOF
           sbatch --wait ci/tests/plain.sbatch || exit 1
           EOF

--- a/ci/tests/Readme.md
+++ b/ci/tests/Readme.md
@@ -2,8 +2,6 @@
 
 | Filename                     | Expectation                                                                                                                   |
 |:-----------------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| `invalid-image.sh`           | plugin fails to mount an inexistent image                                                                                     |
-| `invalid-mount-point.sh`     | plugin fails when mounting on an inexistent path                                                                              |
 | `plain.sbatch`               | nothing is mounted when running sbatch (no uenv flags)                                                                        |
 | `squashfs-run.sh`            | - env variables from squashfs-run are taken into account <br> - env variables have no effect when --uenv-mount-file overrides |
 | `test-override-flags.sbatch` | override flags take precedence                                                                                                |

--- a/ci/tests/invalid-file.sh
+++ b/ci/tests/invalid-file.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. ${SCRIPT_DIR}/util
+
+expect_error 'srun -n 1 --uenv-file=/home/testuser/fs.sqfs --uenv-mount=/path/does/not/exist true'

--- a/ci/tests/invalid-flags.sh
+++ b/ci/tests/invalid-flags.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. ${SCRIPT_DIR}/util
+
+expect_error 'srun --uenv-mount=/user-environment -v true'
+expect_error 'srun --uenv-file=/home/testuser/fs.sqfs --uenv-mount=/user-environment -v true'

--- a/ci/tests/invalid-image.sh
+++ b/ci/tests/invalid-image.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-srun --uenv-file=/does/not/exist true |& grep 'Invalid squashfs image' || exit 1

--- a/ci/tests/invalid-image.sh
+++ b/ci/tests/invalid-image.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. ${SCRIPT_DIR}/util
+
+expect_error 'srun --uenv-file=/does/not/exist true'

--- a/ci/tests/invalid-mount-point.sh
+++ b/ci/tests/invalid-mount-point.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# non-existent mount point
-(srun -n 1 --uenv-file=/home/testuser/fs.sqfs --uenv-mount=/path/does/not/exist true) |& grep "Invalid mount point" || exit 1

--- a/ci/tests/util
+++ b/ci/tests/util
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+expect_error()
+{
+    (
+        set +e
+        if  ! (eval "$1") ; then
+            return 0
+        fi
+        return 1
+    )
+}
+export -f expect_error


### PR DESCRIPTION
Add a bash function `expect_error ARG` to tests, which expects a non-zero exit code of ARG and returns 1 otherwise:
 `expect_error 'srun --uenv-mount=/user-environment true'`
