### PR TITLE
fix container build script

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/bash
 
-set -x
-
 TAG=slurm-uenv-mount
 CONTAINER=$1
 
@@ -9,9 +7,17 @@ if [ ! -z "$CONTAINER" ]; then
     BUILD_ARGS+="--build-arg DOCKER_CONTAINER=${CONTAINER}"
 fi
 
-SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../; pwd)"
+DOCKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/; pwd)"
+SOURCE_DIR=$(realpath "${DOCKER_DIR}/..")
+
+echo
+echo container $CONTAINER
+echo tag $TAG
+echo source $SOURCE_DIR
+echo docker $DOCKER_DIR
+echo
 
 (
-    cd ../ || exit 1
-    BUILDKIT_PROGRESS=plain docker build . -f "${SOURCE_DIR}/Dockerfile" ${BUILD_ARGS} --progress=plain -t $TAG
+    cd ${SOURCE_DIR} || exit 1
+    BUILDKIT_PROGRESS=plain docker build . -f "${DOCKER_DIR}/Dockerfile" ${BUILD_ARGS} --progress=plain -t $TAG
 )


### PR DESCRIPTION
The container build script was failing as it provided the wrong path for the Dockerfile to `docker build`.
This PR fixes this, and makes the `build.sh` a little less chatty.