### PR TITLE
docker/build.sh: The realpath command doesn't exist under MacOSX. Use…

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,16 +5,18 @@ CONTAINER=$1
 
 if [ ! -z "$CONTAINER" ]; then
     BUILD_ARGS+="--build-arg DOCKER_CONTAINER=${CONTAINER}"
+else
+    CONTAINER="-Dockerfile default-"
 fi
 
 DOCKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/; pwd)"
-SOURCE_DIR=$(realpath "${DOCKER_DIR}/..")
+SOURCE_DIR="$(cd ${DOCKER_DIR}/..; pwd)"
 
 echo
-echo container $CONTAINER
-echo tag $TAG
-echo source $SOURCE_DIR
-echo docker $DOCKER_DIR
+echo "container: $CONTAINER"
+echo "tag:       $TAG"
+echo "source:    $SOURCE_DIR"
+echo "docker:    $DOCKER_DIR"
 echo
 
 (


### PR DESCRIPTION
… a bash-ish to get the SOURCE_DIR absolute directory.