### PR TITLE
rpm dependency on slurm, release rpm for multiple slurm versions

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         version:
           - 20.11.9
-          - 21.08.8-2
-          - 22.05.5
+          # - 21.08.8-2
+          - 22.05.2
 
     container:
       image: ghcr.io/eth-cscs/cache_docker/slurm-uenv-mount-tester-${{ matrix.version }}:latest
@@ -23,35 +23,34 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
       env:
         NODE_HW: CPUS=2
+        SLURM_VER: ${{ matrix.version }}
       options: --cpus 2 --privileged
 
     steps:
       - uses: actions/checkout@v3
       - run: |
-          make rpm
+          make RPM_SLURM_VERSION=${SLURM_VER} rpm
           sudo rpmbuild --rebuild "$(find rpm/SRPMS -name '*.rpm' -type f -print -quit)" --define "_topdir $(pwd)/rpm"
-          sudo rpm --install "$(find rpm/RPMS -name '*.rpm' -type f -print -quit)"
+          # TODO: this fails, because the new rpm lists slurm as dependency (image installed slurm manually not via pkg manager)
+          # sudo rpm --install "$(find rpm/RPMS -name '*.rpm' -type f -print -quit)"
           find rpm -name '*.rpm' -type f -exec cp {} . \;
+          fname=$(ls *x86_64.rpm)
+          dstname=$(echo $fname | sed "s/x86_64/x86_64-slurm-${SLURM_VER}/")
+          mv $fname $dstname
       - name: upload-rpm
         uses: actions/upload-artifact@v3
         with:
-          name: rpm-${{ matrix.version }}
+          name: rpm
           path: '*.rpm'
 
   tag-release:
     runs-on: ubuntu-20.04
-    strategy:
-        matrix:
-          version:
-            - 20.11.9
-            # - 21.08.8-2
-            # - 22.05.5
     needs: rpm
     steps:
       - name: download-artifacts
         uses: actions/download-artifact@v3
         with:
-          name: rpm-${{ matrix.version }}
+          name: rpm
       - name: release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         version:
           - 20.11.9
-          # - 21.08.8-2
           - 22.05.2
 
     container:
@@ -31,8 +30,8 @@ jobs:
       - run: |
           make RPM_SLURM_VERSION=${SLURM_VER} rpm
           sudo rpmbuild --rebuild "$(find rpm/SRPMS -name '*.rpm' -type f -print -quit)" --define "_topdir $(pwd)/rpm"
-          # TODO: this fails, because the new rpm lists slurm as dependency (image installed slurm manually not via pkg manager)
-          # sudo rpm --install "$(find rpm/RPMS -name '*.rpm' -type f -print -quit)"
+          # --nodeps is required since the ci container has handbuilt slurm (not installed via rpm)
+          sudo rpm --install --nodeps "$(find rpm/RPMS -name '*.rpm' -type f -print -quit)"
           find rpm -name '*.rpm' -type f -exec cp {} . \;
           fname=$(ls *x86_64.rpm)
           dstname=$(echo $fname | sed "s/x86_64/x86_64-slurm-${SLURM_VER}/")

--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -14,8 +14,7 @@ jobs:
       matrix:
         version:
           - 20.11.9
-          - 21.08.8-2
-          - 22.05.5
+          - 22.05.2
 
     env:
       base_tag:     ghcr.io/eth-cscs/slurm-container-${{ matrix.version }}:latest
@@ -51,8 +50,7 @@ jobs:
       matrix:
         version:
           - 20.11.9
-          - 21.08.8-2
-          - 22.05.5
+          - 22.05.2
 
     container:
       image: ghcr.io/eth-cscs/cache_docker/slurm-uenv-mount-tester-${{ matrix.version }}:latest

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 prefix ?= /usr
 exec_prefix ?= $(prefix)
 libdir ?= $(exec_prefix)/lib64
+RPM_SLURM_VERSION ?= 20.11
 
 CXXFLAGS ?= -Os -Wall -Wpedantic -fPIC -std=c++17 -shared
 LDFLAGS ?= -Wl,--allow-shlib-undefined -shared -fPIC
@@ -39,7 +40,7 @@ install: libslurm-uenv-mount.so
 rpm: $(FILES) $(SRCDIR)slurm-uenv-mount.spec
 	$(SRCDIR)./generate-rpm.sh --build $(RPMBUILDDIR) --src "$(SRCDIR)" --pkgname $(RPMPKG) --spec "$(SRCDIR)slurm-uenv-mount.spec" --files "$(FILES)"
 	sed -i "s|UENVMNT_VERSION|$(SLURM_UENV_MOUNT_VERSION)|g" "$(RPMBUILDDIR)/SPECS/slurm-uenv-mount.spec"
-	sed -i "s|SLURM_VERSION|$$(srun --version | sed 's/slurm //')|g" "$(RPMBUILDDIR)/SPECS/slurm-uenv-mount.spec"
+	sed -i "s|SLURM_VERSION|$(RPM_SLURM_VERSION)|g" "$(RPMBUILDDIR)/SPECS/slurm-uenv-mount.spec"
 	$(RPMBUILD) -bs --define "_topdir $(RPMBUILDDIR)" "$(RPMBUILDDIR)/SPECS/slurm-uenv-mount.spec"
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ install: libslurm-uenv-mount.so
 rpm: $(FILES) $(SRCDIR)slurm-uenv-mount.spec
 	$(SRCDIR)./generate-rpm.sh --build $(RPMBUILDDIR) --src "$(SRCDIR)" --pkgname $(RPMPKG) --spec "$(SRCDIR)slurm-uenv-mount.spec" --files "$(FILES)"
 	sed -i "s|UENVMNT_VERSION|$(SLURM_UENV_MOUNT_VERSION)|g" "$(RPMBUILDDIR)/SPECS/slurm-uenv-mount.spec"
+	sed -i "s|SLURM_VERSION|$$(srun --version | sed 's/slurm //')|g" "$(RPMBUILDDIR)/SPECS/slurm-uenv-mount.spec"
 	$(RPMBUILD) -bs --define "_topdir $(RPMBUILDDIR)" "$(RPMBUILDDIR)/SPECS/slurm-uenv-mount.spec"
 
 clean:

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -46,5 +46,5 @@ When making changes in the local source tree, the plugin can be rebuilt/resintal
 
 Build the binary rpm, e.g. for installation on production system:
 ```bash
-docker compose exec -T slurm bash < make-rpm.sh
+docker compose exec -T slurm bash < make-binary-rpm.sh
 ```

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -43,3 +43,8 @@ When making changes in the local source tree, the plugin can be rebuilt/resintal
 ```bash
 ./rebuild.sh
 ```
+
+Build the binary rpm, e.g. for installation on production system:
+```bash
+docker compose exec -T slurm bash < make-rpm.sh
+```

--- a/docker/make-binary-rpm.sh
+++ b/docker/make-binary-rpm.sh
@@ -8,7 +8,14 @@ cd /tmp/build-rpm
 _SLURM_VER=$(srun --version | sed 's/slurm //')
 make -f /slurm-uenv-mount/Makefile RPM_SLURM_VERSION="${_SLURM_VER}" rpm
 rpmbuild --rebuild "$(find rpm/SRPMS -name '*.rpm' -type f -print -quit)" --define "_topdir $(pwd)/rpm"
+
+rm ./*.rpm
 find rpm -name '*.rpm' -type f -exec cp {} . \;
+
+fname=$(ls *x86_64.rpm)
+dstname=$(echo $fname | sed "s/x86_64/x86_64-slurm-${_SLURM_VER}/")
+mv $fname $dstname
+
 
 echo
 echo "RPM built. "
@@ -16,6 +23,6 @@ echo
 
 echo "Copy from container:"
 echo
-printf "\tdocker compose cp slurm:$(realpath *x86_64.rpm) ."
+printf "\tdocker compose cp slurm:$(realpath $dstname) ."
 echo
 echo

--- a/docker/make-binary-rpm.sh
+++ b/docker/make-binary-rpm.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p /tmp/build-rpm
+cd /tmp/build-rpm
+make -f /slurm-uenv-mount/Makefile rpm
+rpmbuild --rebuild "$(find rpm/SRPMS -name '*.rpm' -type f -print -quit)" --define "_topdir $(pwd)/rpm"
+find rpm -name '*.rpm' -type f -exec cp {} . \;
+
+echo
+echo "RPM built. "
+echo
+
+echo "Copy from container:"
+echo
+printf "\tdocker compose cp slurm:$(realpath *x86_64.rpm) ."
+echo
+echo

--- a/docker/make-binary-rpm.sh
+++ b/docker/make-binary-rpm.sh
@@ -4,7 +4,9 @@ set -e
 
 mkdir -p /tmp/build-rpm
 cd /tmp/build-rpm
-make -f /slurm-uenv-mount/Makefile rpm
+
+_SLURM_VER=$(srun --version | sed 's/slurm //')
+make -f /slurm-uenv-mount/Makefile RPM_SLURM_VERSION="${_SLURM_VER}" rpm
 rpmbuild --rebuild "$(find rpm/SRPMS -name '*.rpm' -type f -print -quit)" --define "_topdir $(pwd)/rpm"
 find rpm -name '*.rpm' -type f -exec cp {} . \;
 

--- a/slurm-uenv-mount.spec
+++ b/slurm-uenv-mount.spec
@@ -3,6 +3,7 @@ Version:        UENVMNT_VERSION
 Release:        1%{?dist}
 Summary:        SLURM spank plugin to mount squashfs images.
 Prefix:         /usr
+Requires:       slurm = SLURM_VERSION
 
 License:        BSD3
 URL:            https://github.com/eth-cscs/slurm-uenv-mount


### PR DESCRIPTION
- add `Require: slurm = SLURM_VERSION` to rpm spec
- makefile takes an option `RPM_SLURM_VERSION` (used only in rpm spec)
- add a script to make create and extract the binary rpm from the container
- Release rpm artifacts for multiple slurm versions