### PR TITLE
slurm version in rpm release tag

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -33,9 +33,6 @@ jobs:
           # --nodeps is required since the ci container has handbuilt slurm (not installed via rpm)
           sudo rpm --install --nodeps "$(find rpm/RPMS -name '*.rpm' -type f -print -quit)"
           find rpm -name '*.rpm' -type f -exec cp {} . \;
-          fname=$(ls *x86_64.rpm)
-          dstname=$(echo $fname | sed "s/x86_64/x86_64-slurm-${SLURM_VER}/")
-          mv $fname $dstname
       - name: upload-rpm
         uses: actions/upload-artifact@v3
         with:

--- a/docker/make-binary-rpm.sh
+++ b/docker/make-binary-rpm.sh
@@ -9,12 +9,9 @@ _SLURM_VER=$(srun --version | sed 's/slurm //')
 make -f /slurm-uenv-mount/Makefile RPM_SLURM_VERSION="${_SLURM_VER}" rpm
 rpmbuild --rebuild "$(find rpm/SRPMS -name '*.rpm' -type f -print -quit)" --define "_topdir $(pwd)/rpm"
 
-rm ./*.rpm
 find rpm -name '*.rpm' -type f -exec cp {} . \;
 
 fname=$(ls *x86_64.rpm)
-dstname=$(echo $fname | sed "s/x86_64/x86_64-slurm-${_SLURM_VER}/")
-mv $fname $dstname
 
 
 echo
@@ -23,6 +20,6 @@ echo
 
 echo "Copy from container:"
 echo
-printf "\tdocker compose cp slurm:$(realpath $dstname) ."
+printf "\tdocker compose cp slurm:$(realpath $fname) ."
 echo
 echo

--- a/slurm-uenv-mount.spec
+++ b/slurm-uenv-mount.spec
@@ -1,6 +1,6 @@
 Name:           slurm-uenv-mount
 Version:        UENVMNT_VERSION
-Release:        1%{?dist}
+Release:        SLURM_VERSION
 Summary:        SLURM spank plugin to mount squashfs images.
 Prefix:         /usr
 Requires:       slurm = SLURM_VERSION


### PR DESCRIPTION
Having multiple packages of the same slurm-uenv-mount version for different slurm-versions creates a clash in the rpm repo. When the rpms are loaded into the repository accessed from alps, zypper apparently cannot differentiate between the slurm-versions.

A work around is to use the release tag of the rpm to store the slurm version:

```
$ rpm -qi slurm-uenv-mount-0.5-20.11.9.x86_64.rpm
Name        : slurm-uenv-mount
Version     : 0.5
Release     : 20.11.9
Architecture: x86_64
...
A SLURM spank plugin to mount squashfs images.
````


An alternative solution would be to append the slurm version to the `Version` field, e.g. `Version: 0.5.20.11.9` in the example below.
