### PR TITLE
use abs paths (via cstdlib realpath)

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -108,3 +108,10 @@ jobs:
           # this is expected to vail
           ci/tests/invalid-flags.sh
           EOF
+      - run: |
+          # check that relative paths are converted to absolute paths
+          su testuser -c -m sh <<\EOF
+          script=$(realpath ci/tests/relative-path.sbatch)
+          cd ~
+          sbatch --wait $script || exit 1
+          EOF

--- a/ci/tests/relative-path.sbatch
+++ b/ci/tests/relative-path.sbatch
@@ -1,0 +1,12 @@
+#!/bin/bash
+#SBATCH --ntasks=2
+#SBATCH --uenv-file=./fs.sqfs
+#SBATCH --output=/tmp/stdout.txt
+#SBATCH --error=/tmp/stderr.txt
+
+cd /var/log || exit
+
+echo "in local context: $(stat /user-environment/test)"
+srun -n 1 sh <<\EOF
+   echo "from inside srun node ${SLURM_NODEID}, task ${SLURM_TASK_PID}: $(stat /user-environment/test)"
+EOF

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -30,12 +30,12 @@ docker compose up -d
 
 Launch a shell in the container as unprivileged user:
 ```bash
-docker compose exec -u testuser -w /home/testuser slurm bash
+docker compose exec --privileged -u testuser -w /home/testuser slurm bash
 ```
 
 Run tests:
 ```bash
-docker compose exec -u testuser -w /home/testuser -T slurm bash < run-tests.sh
+docker compose exec --privileged -u testuser -w /home/testuser -T slurm bash < run-tests.sh
 ```
 
 The source code is mounted read-only inside the container under `/slurm-uenv-mount`.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,6 @@ services:
     build:
       context: ../
       args:
-        DOCKER_CONTAINER: ghcr.io/eth-cscs/slurm-container-20.11.9:latest
+        DOCKER_CONTAINER: ghcr.io/eth-cscs/slurm-container-22.05.2:latest
       dockerfile: docker/Dockerfile
     command: tail -F anything

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -17,31 +17,50 @@ run_sbatch()
 }
 
 (
-    while IFS= read -r -d '' file
-    do
-        run_sbatch "${file}"
-    done <   <(find /slurm-uenv-mount/ci/tests -iname '*.sbatch' -print0)
+    # while IFS= read -r -d '' file
+    # do
+    #     run_sbatch "${file}"
+    # done <   <(find /slurm-uenv-mount/ci/tests -iname '*.sbatch' -print0)
 
+    # echo "-----------------------------------------------------------------------"
+    # echo "test inheritance of UENV_MOUNT_FILE/POINT in dummy squashfs-run session"
+    # echo "-----------------------------------------------------------------------"
+    # run_test_script /slurm-uenv-mount/ci/tests/squashfs-run.sh
+
+    # echo "-----------------------------------------------------------------------"
+    # echo "invalid.image.sh (expectation: slurm error)                            "
+    # echo "-----------------------------------------------------------------------"
+    # run_test_script /slurm-uenv-mount/ci/tests/invalid-image.sh
+
+    # echo "-----------------------------------------------------------------------"
+    # echo "invalid-file.sh (expectation: slurm error)                             "
+    # echo "-----------------------------------------------------------------------"
+    # run_test_script /slurm-uenv-mount/ci/tests/invalid-file.sh
+
+    # echo "-----------------------------------------------------------------------"
+    # echo "invalid-flags.sh (expectation: slurm error)                             "
+    # echo "-----------------------------------------------------------------------"
+    # run_test_script /slurm-uenv-mount/ci/tests/invalid-flags.sh
+
+    # echo "-----------------------------------------------------------------------"
+    # echo "relative paths (check)                                                 "
+    # echo "-----------------------------------------------------------------------"
+    # (
+    #     set -x
+    #     sbatch /slurm-uenv-mount/ci/tests/relative-path.sbatch
+    # )
 
     echo "-----------------------------------------------------------------------"
-    echo "test inheritance of UENV_MOUNT_FILE/POINT in dummy squashfs-run session"
+    echo "relative paths                                                         "
     echo "-----------------------------------------------------------------------"
-    run_test_script /slurm-uenv-mount/ci/tests/squashfs-run.sh
+    (
+        set -x
+        script=$(realpath /slurm-uenv-mount/ci/tests/relative-path.sbatch)
+        echo "script: ${script}"
+        cd ~
+        sbatch --wait $script
+    )
 
-    echo "-----------------------------------------------------------------------"
-    echo "invalid.image.sh (expectation: slurm error)                            "
-    echo "-----------------------------------------------------------------------"
-    run_test_script /slurm-uenv-mount/ci/tests/invalid-image.sh
-
-    echo "-----------------------------------------------------------------------"
-    echo "invalid-file.sh (expectation: slurm error)                             "
-    echo "-----------------------------------------------------------------------"
-    run_test_script /slurm-uenv-mount/ci/tests/invalid-file.sh
-
-    echo "-----------------------------------------------------------------------"
-    echo "invalid-flags.sh (expectation: slurm error)                             "
-    echo "-----------------------------------------------------------------------"
-    run_test_script /slurm-uenv-mount/ci/tests/invalid-flags.sh
 ) || (printf 'TESTS FAILED' && exit 1)
 
 echo

--- a/mount.hpp
+++ b/mount.hpp
@@ -1,13 +1,13 @@
 extern "C" {
 #include <slurm/spank.h>
 }
+#include <string>
 
 #define ENV_MOUNT_FILE "UENV_MOUNT_FILE"
 #define ENV_MOUNT_POINT "UENV_MOUNT_POINT"
-// #define ENV_MOUNT_SKIP_PROLOGUE "SLURM_UENV_MOUNT_PROLOGUE"
 
 namespace impl {
 
-int do_mount(spank_t spank, const char *mount_point, const char *squashfs_file);
+int do_mount(spank_t spank, const std::string& mount_point, const std::string& squashfs_file);
 
 } // namespace impl


### PR DESCRIPTION
Use `SLURM_SUBMIT_DIR` to convert relative paths to absolute paths

Example:

```
salloc --uenv-file=./image.sqfs

cd /

# works, image is read from $SLURM_SUBMIT_DIR/image.sqfs
srun true

# fails, $SLURM_SUBMIT_DIR will be prepended
srun --uenv-file=./new-image.sqfs
```

Problem: I haven't found a way of detecting whether `--uenv-file` has been specified (overriden) explicitly for the current step or not. If `--uenv-file` was inherited from sbatch/salloc `$SLURM_SUBMIT_DIR` can be used to resolve the path. But if  directory was changed and `--uenv-file` has been repeated with a relative path, prepend $SLURM_SUBMIT_DIR (which is the directory where salloc/sbatch has been called) will fail.