### PR TITLE
mount in `spank_init_post_opt` call only in remote context

### DIFF
--- a/mount.cpp
+++ b/mount.cpp
@@ -20,6 +20,35 @@ extern "C" {
 
 namespace impl {
 
+
+int check_mount_file_is_valid(const std::string& mount_point, const std::string& squashfs_file)
+{
+  struct stat mnt_stat;
+  auto mnt_status = stat(mount_point.c_str(), &mnt_stat);
+  if (mnt_status) {
+    slurm_spank_log("Invalid mount point \"%s\"", mount_point.c_str());
+    return -ESPANK_ERROR;
+  }
+  if (!S_ISDIR(mnt_stat.st_mode)) {
+    slurm_spank_log("Invalid mount point \"%s\" is not a directory",
+                    mount_point.c_str());
+    return -ESPANK_ERROR;
+  }
+  // Check that the input squashfs file exists.
+  int sqsh_status = stat(squashfs_file.c_str(), &mnt_stat);
+  if (sqsh_status) {
+    slurm_spank_log("Invalid squashfs image \"%s\"", squashfs_file.c_str());
+    return -ESPANK_ERROR;
+  }
+  if (!S_ISREG(mnt_stat.st_mode)) {
+    slurm_spank_log("Invalid squashfs image \"%s\" is not a file",
+                    squashfs_file.c_str());
+    return -ESPANK_ERROR;
+  }
+
+  return ESPANK_SUCCESS;
+}
+
 int do_mount(spank_t spank, const std::string& mount_point, const std::string& squashfs_file) {
   // Check that the mount point exists.
   struct stat mnt_stat;

--- a/mount.hpp
+++ b/mount.hpp
@@ -1,13 +1,13 @@
 extern "C" {
 #include <slurm/spank.h>
 }
+#include <string>
 
 #define ENV_MOUNT_FILE "UENV_MOUNT_FILE"
 #define ENV_MOUNT_POINT "UENV_MOUNT_POINT"
-// #define ENV_MOUNT_SKIP_PROLOGUE "SLURM_UENV_MOUNT_PROLOGUE"
 
 namespace impl {
 
-int do_mount(spank_t spank, const char *mount_point, const char *squashfs_file);
+int do_mount(spank_t spank, const std::string& mount_point, const std::string& squashfs_file);
 
 } // namespace impl

--- a/mount.hpp
+++ b/mount.hpp
@@ -8,6 +8,7 @@ extern "C" {
 
 namespace impl {
 
+int check_mount_file_is_valid(const std::string& mount_point, const std::string& squashfs_file);
 int do_mount(spank_t spank, const std::string& mount_point, const std::string& squashfs_file);
 
 } // namespace impl

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -168,18 +168,8 @@ int init_post_opt_local_allocator(spank_t sp) {
   if (args.file) {
     return check_mount_file_is_valid(args.mount_point, *args.file);
   }
-  // check if sbatch/srun/salloc was called inside squashfs-run tty
-  std::optional<std::string> env_file, env_mount_point;
-  try {
-    std::tie(env_file, env_mount_point) = get_squashfs_run_env(sp);
-  } catch (spank_err_t err) {
-    slurm_error("%s", spank_strerror(err));
-    return err;
-  }
-  if (env_file && env_mount_point) {
-    return check_mount_file_is_valid(*env_mount_point, *env_file);
-  }
-
+  // env UENV_MOUNT_FILE, UENV_MOUNT_POINT doesn't require to be checked,
+  // they are guaranteed to be absolute paths and have been mounted already
   return ESPANK_SUCCESS;
 }
 


### PR DESCRIPTION
- call `do_mount` in `spank_init_post_opt` (only in remote context)
- convert relative paths for `--uenv-file` and `--uenv-mount` to absolute paths, assuming they have been given relative to `SLURM_SUBMIT_DIR`