### PR TITLE
don't allow empty --uenv='' or --uenv=[,]*

### DIFF
--- a/ci/tests/test.bats
+++ b/ci/tests/test.bats
@@ -111,3 +111,13 @@ EOF
     run_srun_unchecked --uenv=a:b:c:/user-tools true
     assert_output --partial 'Invalid syntax for --uenv'
 }
+
+@test "empty_argument1" {
+    run_srun_unchecked --uenv='' true
+    assert_output --partial 'No mountpoints given.'
+}
+
+@test "empty_argument2" {
+    run_srun_unchecked --uenv=,,, true
+    assert_output --partial 'No mountpoints given.'
+}

--- a/src/parse_args.cpp
+++ b/src/parse_args.cpp
@@ -42,6 +42,10 @@ parse_arg(const std::string &arg) {
   std::vector<mount_entry> entries;
   std::vector<std::string> arguments = split(arg, ',');
 
+  if(arguments.empty()) {
+    return util::unexpected("No mountpoints given.");
+  }
+
   for (auto &entry : arguments) {
     std::smatch match_pieces;
     if (std::regex_match(entry, match_pieces, protocol_pattern)) {


### PR DESCRIPTION
Fix for https://github.com/eth-cscs/slurm-uenv-mount/issues/36:

- return an error if `--uenv` has been called with an empty argument (or a list of empty arguments aka ',,,,')
- add a corresponding test and assert failure