### PR TITLE
remove "file://" from envvar

### DIFF
--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -161,7 +161,7 @@ int init_post_opt_remote(spank_t sp,
   for (auto &entry : mount_entries) {
     auto abs_image = *util::realpath(entry.image_path);
     auto abs_mount = *util::realpath(entry.mount_point);
-    env_var += "file://" + abs_image + ":" + abs_mount + ",";
+    env_var += abs_image + ":" + abs_mount + ",";
   }
   if (mount_entries.size() > 0) {
     spank_setenv(sp, UENV_MOUNT_LIST, env_var.c_str(), 1);


### PR DESCRIPTION
There was another instance of `file://` in the code, the plugin exported the image path using `file://` prefix. Causing subsequent srun to fail.

This has been fixed already https://github.com/eth-cscs/slurm-uenv-mount/pull/44. 

The current PR removes the inconsistent setting of UENV_MOUNT_LIST. `squashfs-mount` omits `file://`.